### PR TITLE
Feature/dump

### DIFF
--- a/src/component/assets/GfxImage.cpp
+++ b/src/component/assets/GfxImage.cpp
@@ -1,0 +1,184 @@
+#include <std_include.hpp>
+#include "loader/component_loader.hpp"
+
+#include "component/assethandler.hpp"
+#include "component/command.hpp"
+#include "component/console.hpp"
+#include "component/map_dumper.hpp"
+#include "component/scheduler.hpp"
+
+#include "game/game.hpp"
+#include "game/structs.IW4.hpp"
+
+#include <utils/memory.hpp>
+#include <utils/hook.hpp>
+
+#define IW4X_IMG_VERSION "0"
+
+static_assert(sizeof game::iw4::GfxImageFileHeader::tag == sizeof game::qos::GfxImageFileHeader::tag, "tag size mismatch!");
+static_assert(sizeof game::iw4::GfxImageFileHeader::dimensions == sizeof game::qos::GfxImageFileHeader::dimensions, "dimensions size mismatch!");
+static_assert(sizeof game::iw4::GfxImageFileHeader::fileSizeForPicmip == sizeof game::qos::GfxImageFileHeader::fileSizeForPicmip, "fileSizeForPicmip size mismatch!");
+
+namespace gfximage
+{
+	namespace
+	{
+		static const std::unordered_set<std::string> imagesToRename =
+		{
+			"xpec_electrical_transformer_col", // Used between IW3 and IW4 but very different texture
+			"xpec_electrical_transformer_nml",
+			"refrigerator2_col", // Blue fridge in IW4, red in IW3
+			"refrigerator2_nml",
+			"refrigerator_col", // Different fridge texture
+			"refrigerator_nml",
+		};
+
+		static std::unordered_map<std::string, std::string> imagesRenamed{};
+		static std::unordered_map<std::string, std::string> imagesRenamedReverse{};
+
+		const std::string imageSuffix = "_3x";
+
+		int TranslateFlags(int iw3Flags)
+		{
+			int iw4Flags = 0;
+
+			const auto translateFlags = [&](game::qos::file_image_flags_t sourceFlag, game::iw4::file_image_flags_t targetFlag)
+				{
+					if (iw3Flags & sourceFlag)
+					{
+						iw4Flags |= targetFlag;
+					}
+				};
+
+			translateFlags(game::qos::IMG_FLAG_NOPICMIP, game::iw4::IMG_FLAG_NOPICMIP);
+			translateFlags(game::qos::IMG_FLAG_NOMIPMAPS, game::iw4::IMG_FLAG_NOMIPMAPS);
+			translateFlags(game::qos::IMG_FLAG_CUBEMAP, game::iw4::IMG_FLAG_MAPTYPE_CUBE);
+			translateFlags(game::qos::IMG_FLAG_VOLMAP, game::iw4::IMG_FLAG_MAPTYPE_3D);
+			translateFlags(game::qos::IMG_FLAG_STREAMING, game::iw4::IMG_FLAG_STREAMING);
+			translateFlags(game::qos::IMG_FLAG_LEGACY_NORMALS, game::iw4::IMG_FLAG_LEGACY_NORMALS);
+			translateFlags(game::qos::IMG_FLAG_CLAMP_U, game::iw4::IMG_FLAG_CLAMP_U);
+			translateFlags(game::qos::IMG_FLAG_CLAMP_V, game::iw4::IMG_FLAG_CLAMP_V);
+
+			// Not sure about these
+			//translateFlags(game::qos::IMG_FLAG_DYNAMIC,        game::iw4::IMG_FLAG_DYNAMIC);
+			//translateFlags(game::qos::IMG_FLAG_RENDER_TARGET,  game::iw4::IMG_FLAG_RENDER_TARGET);
+			//translateFlags(game::qos::IMG_FLAG_SYSTEMMEM,      game::iw4::IMG_FLAG_SYSTEMMEM);
+
+			//iw4Flags |= game::iw4::IMG_FLAG_ALPHA_WEIGHTED_COLORS;
+			//iw4Flags |= game::iw4::IMG_FLAG_GAMMA_SRGB;
+
+			return iw4Flags;
+		}
+
+		game::iw4::GfxImageLoadDef* ConvertLoadDef(game::qos::GfxImageLoadDef* qosLoadDef)
+		{
+			auto iw4Def = reinterpret_cast<game::iw4::GfxImageLoadDef*>(utils::memory::allocate(sizeof(game::iw4::GfxImageLoadDef) + qosLoadDef->resourceSize - 4));
+
+			std::memcpy(iw4Def->data, qosLoadDef->data, qosLoadDef->resourceSize);
+			iw4Def->flags = TranslateFlags(qosLoadDef->flags);
+			iw4Def->format = qosLoadDef->format;
+			iw4Def->levelCount = qosLoadDef->levelCount;
+			iw4Def->resourceSize = qosLoadDef->resourceSize;
+
+			return iw4Def;
+		}
+
+		game::iw4::GfxImage* convert(game::qos::GfxImage* image)
+		{
+			if (!image) return nullptr;
+
+			if (image == nullptr || &image == NULL) return nullptr;
+
+			std::string name = image->name;
+			if (name[0] == '*') name.erase(name.begin());
+
+			auto iw4Image = utils::memory::allocate<game::iw4::GfxImage>();
+			
+			iw4Image->texture.loadDef = ConvertLoadDef(image->texture.loadDef);
+
+			iw4Image->mapType = static_cast<unsigned char>(image->mapType);
+			iw4Image->semantic = static_cast<unsigned char>(image->semantic);
+			iw4Image->category = image->category;
+			iw4Image->picmip = image->picmip;
+			iw4Image->noPicmip = image->noPicmip;
+			iw4Image->track = image->track;
+			iw4Image->cardMemory = image->cardMemory;
+			iw4Image->width = image->width;
+			iw4Image->height = image->height;
+			iw4Image->depth = image->depth;
+			iw4Image->delayLoadPixels = image->delayLoadPixels;
+			iw4Image->name = image->name;
+
+			return { iw4Image };
+		}
+
+		utils::hook::detour StoreTextureDetour;
+		void StoreTextureHook()
+		{
+			game::qos::GfxImageLoadDef** loadDef = *reinterpret_cast<game::qos::GfxImageLoadDef***>(game::game_offset(0x10AB8F58));
+			game::qos::GfxImage* image = *reinterpret_cast<game::qos::GfxImage**>(game::game_offset(0x10AB8E00));
+
+			size_t size = 16 + (*loadDef)->resourceSize;
+			void* data = utils::memory::get_allocator()->allocate(size);
+			std::memcpy(data, *loadDef, size);
+
+			image->texture.loadDef = reinterpret_cast<game::qos::GfxImageLoadDef*>(data);
+		}
+
+		utils::hook::detour ReleaseTextureDetour;
+		void ReleaseTextureHook(game::qos::XAssetHeader header)
+		{
+			if (header.image && header.image->texture.loadDef)
+			{
+				utils::memory::get_allocator()->free(header.image->texture.loadDef);
+			}
+		}
+	}
+
+	class component final : public component_interface
+	{
+	public:
+		void post_load() override
+		{
+			scheduler::once([&]()
+			{
+				command::add("dumpGfxImage", [](const command::params& params)
+				{
+					if (params.size() < 2)
+					{
+						console::info("USAGE: dumpGfxImage <name>\n");
+						return;
+					}
+
+					const auto name = params[1];
+
+					auto header = game::DB_FindXAssetHeader(game::qos::ASSET_TYPE_IMAGE, name);
+					if (!header.image)
+					{
+						console::error("dumpGfxImage failed on '%s'\n", name);
+						return;
+					}
+
+					auto converted = gfximage::convert(header.image);
+					map_dumper::api->write(game::iw4::ASSET_TYPE_IMAGE, converted);
+
+					console::info("dumped '%s' for IW4\n", name);
+				});
+				//StoreTextureDetour.create(game::game_offset(0x103ADD20), StoreTextureHook);
+				//ReleaseTextureDetour.create(game::game_offset(0x103ADD20), ReleaseTextureHook);
+			}, scheduler::main);
+		}
+
+		game::qos::XAssetType get_type() override
+		{
+			return game::qos::ASSET_TYPE_IMAGE;
+		}
+
+		game::iw4::XAssetHeader convert_asset(game::qos::XAssetHeader header) override
+		{
+			return { convert(header.image) };
+		}
+	};
+}
+
+REGISTER_COMPONENT(gfximage::component)

--- a/src/component/assets/GfxWorld.cpp
+++ b/src/component/assets/GfxWorld.cpp
@@ -1,79 +1,79 @@
 #include <std_include.hpp>
-#include "loader/component_loader.hpp"
-
-#include "component/assethandler.hpp"
-#include "component/command.hpp"
-#include "component/console.hpp"
-#include "component/map_dumper.hpp"
-#include "component/scheduler.hpp"
-
-#include "game/game.hpp"
-#include "game/structs.IW4.hpp"
-
-#include <utils/memory.hpp>
-
-namespace gfxworld
-{
-	namespace
-	{
-		game::iw4::GfxWorld* convert(game::qos::GfxWorld* world)
-		{
-			if (!world) return nullptr;
-
-			game::iw4::GfxSky* sky = utils::memory::allocate<game::iw4::GfxSky>();
-
-			game::iw4::GfxWorld map;
-			ZeroMemory(&map, sizeof(map));
-
-			map.name = world->name;
-			map.baseName = world->baseName;
-
-			return { iw4_asset };
-		}
-	}
-
-	class component final : public component_interface
-	{
-	public:
-		void post_load() override
-		{
-			scheduler::once([&]()
-			{
-				command::add("dumpgfxworld", [](const command::params& params)
-				{
-					if (params.size() < 2)
-					{
-						console::info("USAGE: dumpgfxworld <name>\n");
-						return;
-					}
-
-					const auto name = params[1];
-
-					auto header = game::DB_FindXAssetHeader(game::qos::ASSET_TYPE_GFXWORLD, name);
-					if (!header.comWorld)
-					{
-						console::error("dumpgfxworld failed on '%s'\n", name);
-						return;
-					}
-
-					auto converted = gfxworld::convert(header.comWorld);
-					map_dumper::api->write(game::iw4::ASSET_TYPE_GFXWORLD, converted);
-
-					console::info("dumped '%s' for IW4\n", name);
-				});
-			}, scheduler::main);
-		}
-
-		game::qos::XAssetType get_type() override
-		{
-			return game::qos::ASSET_TYPE_GFXWORLD;
-		}
-
-		game::iw4::XAssetHeader convert_asset(game::qos::XAssetHeader header) override
-		{
-			return { convert(header.gfxWorld) };
-		}
-	};
-}
-
-REGISTER_COMPONENT(gfxworld::component)
+//#include "loader/component_loader.hpp"
+//
+//#include "component/assethandler.hpp"
+//#include "component/command.hpp"
+//#include "component/console.hpp"
+//#include "component/map_dumper.hpp"
+//#include "component/scheduler.hpp"
+//
+//#include "game/game.hpp"
+//#include "game/structs.IW4.hpp"
+//
+//#include <utils/memory.hpp>
+//
+//namespace gfxworld
+//{
+//	namespace
+//	{
+//		game::iw4::GfxWorld* convert(game::qos::GfxWorld* world)
+//		{
+//			if (!world) return nullptr;
+//
+//			game::iw4::GfxSky* sky = utils::memory::allocate<game::iw4::GfxSky>();
+//
+//			game::iw4::GfxWorld map;
+//			ZeroMemory(&map, sizeof(map));
+//
+//			map.name = world->name;
+//			map.baseName = world->baseName;
+//
+//			return { iw4_asset };
+//		}
+//	}
+//
+//	class component final : public component_interface
+//	{
+//	public:
+//		void post_load() override
+//		{
+//			scheduler::once([&]()
+//			{
+//				command::add("dumpgfxworld", [](const command::params& params)
+//				{
+//					if (params.size() < 2)
+//					{
+//						console::info("USAGE: dumpgfxworld <name>\n");
+//						return;
+//					}
+//
+//					const auto name = params[1];
+//
+//					auto header = game::DB_FindXAssetHeader(game::qos::ASSET_TYPE_GFXWORLD, name);
+//					if (!header.comWorld)
+//					{
+//						console::error("dumpgfxworld failed on '%s'\n", name);
+//						return;
+//					}
+//
+//					auto converted = gfxworld::convert(header.comWorld);
+//					map_dumper::api->write(game::iw4::ASSET_TYPE_GFXWORLD, converted);
+//
+//					console::info("dumped '%s' for IW4\n", name);
+//				});
+//			}, scheduler::main);
+//		}
+//
+//		game::qos::XAssetType get_type() override
+//		{
+//			return game::qos::ASSET_TYPE_GFXWORLD;
+//		}
+//
+//		game::iw4::XAssetHeader convert_asset(game::qos::XAssetHeader header) override
+//		{
+//			return { convert(header.gfxWorld) };
+//		}
+//	};
+//}
+//
+//REGISTER_COMPONENT(gfxworld::component)

--- a/src/component/assets/MapEnts.cpp
+++ b/src/component/assets/MapEnts.cpp
@@ -1,0 +1,94 @@
+#include <std_include.hpp>
+#include "loader/component_loader.hpp"
+
+#include "component/assethandler.hpp"
+#include "component/command.hpp"
+#include "component/console.hpp"
+#include "component/map_dumper.hpp"
+#include "component/scheduler.hpp"
+
+#include "game/game.hpp"
+#include "game/structs.IW4.hpp"
+
+#include <utils/memory.hpp>
+#include <utils/string.hpp>
+#include <component/entities.hpp>
+
+namespace mapents
+{
+	namespace
+	{
+		game::iw4::MapEnts* convert(game::qos::MapEnts* ents)
+		{
+			if (!ents) return nullptr;
+
+			std::string entString(ents->entityString, ents->numEntityChars - 1);
+
+			Entities mapEnts(entString);
+
+			mapEnts.AddRemovedSModels(); ///TODO
+
+			entString = mapEnts.Build();
+			const auto models = mapEnts.GetModels();
+
+			auto iw4_asset = utils::memory::allocate<game::iw4::MapEnts>();
+
+			iw4_asset->name = ents->name;
+			iw4_asset->entityString = utils::memory::duplicate_string(entString);
+			iw4_asset->numEntityChars = entString.size() + 1;
+			iw4_asset->stages = nullptr;
+
+			for (const std::string& model : models)
+			{
+				command::execute(utils::string::va("dumpxmodel %s", model.data()));
+			}
+
+			return { iw4_asset };
+		}
+
+		class component final : public component_interface
+		{
+		public:
+			void post_load() override
+			{
+				scheduler::once([&]()
+					{
+						command::add("dumpMapEnts", [](const command::params& params)
+						{
+							if (params.size() < 2)
+							{
+								console::info("USAGE: dumpMapEnts <name>\n");
+								return;
+							}
+
+							const auto name = params[1];
+
+							auto header = game::DB_FindXAssetHeader(game::qos::ASSET_TYPE_CLIPMAP_MP, name);
+							if (!header.clipMap->mapEnts)
+							{
+								console::error("dumpMapEnts failed on '%s'\n", name);
+								return;
+							}
+
+							auto converted = mapents::convert(header.clipMap->mapEnts);
+							map_dumper::api->write(game::iw4::ASSET_TYPE_MAP_ENTS, converted);
+
+							console::info("dumped '%s' for IW4\n", name);
+						});
+					}, scheduler::main);
+			}
+
+			game::qos::XAssetType get_type() override
+			{
+				return game::qos::ASSET_TYPE_MAP_ENTS;
+			}
+
+			game::iw4::XAssetHeader convert_asset(game::qos::XAssetHeader header) override
+			{
+				return { convert(header.clipMap->mapEnts) };
+			}
+		};
+	}
+}
+
+REGISTER_COMPONENT(mapents::component)

--- a/src/component/assets/Material.cpp
+++ b/src/component/assets/Material.cpp
@@ -1,0 +1,188 @@
+#include <std_include.hpp>
+#include "loader/component_loader.hpp"
+
+#include "component/assethandler.hpp"
+#include "component/command.hpp"
+#include "component/console.hpp"
+#include "component/map_dumper.hpp"
+#include "component/scheduler.hpp"
+
+#include "game/game.hpp"
+#include "game/structs.IW4.hpp"
+
+#include <utils/memory.hpp>
+
+namespace material
+{
+	namespace
+	{
+		game::iw4::Material* convert(game::qos::Material* material)
+		{
+			if (!material) return nullptr;
+
+			auto iw4_asset = utils::memory::allocate<game::iw4::Material>();
+			auto iw4_asset_newSurf = utils::memory::allocate<game::iw4::GfxDrawSurf>();
+
+			iw4_asset->name = material->info.name;
+			iw4_asset->gameFlags.packed = material->info.gameFlags.packed;
+			iw4_asset->gameFlags.fields.unk7 = material->info.gameFlags.fields.unkNeededForSModelDisplay;
+			iw4_asset->gameFlags.fields.unkCastShadowMaybe = material->info.gameFlags.fields.MTL_GAMEFLAG_CASTS_SHADOW;
+			iw4_asset->sortKey = material->info.sortKey;
+
+			iw4_asset->textureAtlasRowCount = material->info.textureAtlasRowCount;
+			iw4_asset->textureAtlasColumnCount = material->info.textureAtlasColumnCount;
+
+			iw4_asset_newSurf->fields.objectId = material->info.drawSurf.fields.objectId;
+			iw4_asset_newSurf->fields.reflectionProbeIndex = material->info.drawSurf.fields.reflectionProbeIndex;
+			iw4_asset_newSurf->fields.customIndex = material->info.drawSurf.fields.customIndex;
+			iw4_asset_newSurf->fields.materialSortedIndex = material->info.drawSurf.fields.materialSortedIndex;
+			iw4_asset_newSurf->fields.prepass = material->info.drawSurf.fields.prepass;
+			iw4_asset_newSurf->fields.sceneLightIndex = material->info.drawSurf.fields.primaryLightIndex;
+			iw4_asset_newSurf->fields.surfType = material->info.drawSurf.fields.surfType;
+			iw4_asset_newSurf->fields.primarySortKey = material->info.drawSurf.fields.primarySortKey;
+			iw4_asset->drawSurf.packed = iw4_asset_newSurf->packed;
+
+			iw4_asset->surfaceTypeBits = material->info.surfaceTypeBits;
+			iw4_asset->hashIndex = material->info.hashIndex;
+
+			// Set them all to -1 so they're not used if they dont exist in iw3
+			std::memset(iw4_asset->stateBitsEntry, 0xFF, sizeof(iw4_asset->stateBitsEntry));
+
+			//// copy techniques to correct spots
+			//for (size_t i = 0; i < game::iw4::TECHNIQUE_COUNT; i++)
+			//{
+			//	game::iw4::MaterialTechniqueType technique = static_cast<game::iw4::MaterialTechniqueType>(i);
+			//	if (IMaterialTechniqueSet::techniqueTypeTableFromIW4.contains(technique))
+			//	{
+			//		iw4_asset->stateBitsEntry[technique] = material->stateBitsEntry[IMaterialTechniqueSet::techniqueTypeTableFromIW4.at(technique)];
+			//	}
+			//	else
+			//	{
+			//		// Not necessary
+			//		//iw4_asset->stateBitsEntry[technique] = 0xFF;
+			//	}
+			//}
+
+			iw4_asset->textureCount = material->textureCount;
+			iw4_asset->constantCount = material->constantCount;
+			iw4_asset->stateBitsCount = material->stateBitsCount;
+			iw4_asset->stateFlags = static_cast<game::iw4::StateFlags>(material->stateFlags); // Correspondance is identical
+
+			if (iw4_asset->sortKey == 0)
+			{
+				iw4_asset->stateFlags = static_cast<game::iw4::StateFlags>(iw4_asset->stateFlags | game::iw4::STATE_FLAG_AMBIENT);
+				console::info("Added STATE_FLAG_AMBIENT on {} (sortkey is opaque-ambient)\n", iw4_asset->name);
+			}
+
+			// Should we give ambient stateflag to everybody by default?
+			iw4_asset->cameraRegion = material->cameraRegion;
+
+			if (iw4_asset->cameraRegion == 0x3) {
+				// 0x3 is NONE in iw3, but DEPTH_HACK in iw4
+				// In iw4 NONE is 0x4
+				console::info("Swapped material {} camera region from 0x3 to 0x4 (NONE)\n", iw4_asset->name);
+				iw4_asset->cameraRegion = 0x4;
+			}
+
+			//iw4_asset->techniqueSet = AssetHandler::Convert(Game::IW3::XAssetType::ASSET_TYPE_TECHNIQUE_SET, { material->techniqueSet }).techniqueSet;
+
+
+			iw4_asset->textureTable = utils::memory::allocate_array<game::iw4::MaterialTextureDef>(iw4_asset->textureCount);
+			for (char i = 0; i < iw4_asset->textureCount; i++)
+			{
+				auto qosDef = &material->textureTable[i];
+				auto iw4Def = &iw4_asset->textureTable[i];
+
+				static_assert(sizeof game::iw4::MaterialTextureDef == sizeof game::qos::MaterialTextureDef);
+				std::memcpy(iw4Def, qosDef, sizeof game::iw4::MaterialTextureDef);
+
+
+				if (iw4Def->semantic == 0xB) // TS_Water
+				{
+					console::error("Doesn't support water for now");
+				}
+				else
+				{
+					auto imageAsset = assethandler::convert_asset_header(game::qos::ASSET_TYPE_IMAGE, { qosDef->image }).image;
+					iw4Def->u.image = imageAsset;
+				}
+			}
+
+			iw4_asset->constantTable = nullptr;
+			if (material->contantTable)
+			{
+				iw4_asset->constantTable = utils::memory::allocate_array<game::qos::MaterialConstantDef>(material->constantCount);
+
+				for (char i = 0; i < material->constantCount; ++i)
+				{
+					game::qos::MaterialConstantDef* constantDef = &material->contantTable[i];
+					game::qos::MaterialConstantDef* targetDef = &iw4_asset->constantTable[i];
+
+					std::memcpy(targetDef, constantDef, sizeof(game::qos::MaterialConstantDef));
+
+					if (targetDef->name == "envMapParms"s)
+					{
+						// These use the speculars to add some rimlight effects to models
+						// But since speculars are regenerated we end up with cod6 speculars with cod4 materials
+						// and cod6 speculars are a bit too bright for 
+
+						targetDef->literal[0] *= 0.0875f; // envMapMin
+						targetDef->literal[1] *= 0.2f;  // envMapMax
+						targetDef->literal[2] *= 1.4f;    // engMapExponent
+						targetDef->literal[3] *= 2.2f;    // envMapIntensity
+					}
+
+				}
+			}
+
+			iw4_asset->stateBitTable = material->stateBitsTable;
+
+			return { iw4_asset };
+		}
+	}
+
+	class component final : public component_interface
+	{
+	public:
+		void post_load() override
+		{
+			scheduler::once([&]()
+			{
+				command::add("dumpmaterial", [](const command::params& params)
+				{
+					if (params.size() < 2)
+					{
+						console::info("USAGE: dumpmaterial <name>\n");
+						return;
+					}
+
+					const auto name = params[1];
+
+					auto header = game::DB_FindXAssetHeader(game::qos::ASSET_TYPE_MATERIAL, name);
+					if (!header.material)
+					{
+						console::error("dumpmaterial failed on '%s'\n", name);
+						return;
+					}
+
+					auto converted = material::convert(header.material);
+					map_dumper::api->write(game::iw4::ASSET_TYPE_MATERIAL, converted);
+
+					console::info("dumped '%s' for IW4\n", name);
+				});
+			}, scheduler::main);
+		}
+
+		game::qos::XAssetType get_type() override
+		{
+			return game::qos::ASSET_TYPE_MATERIAL;
+		}
+
+		game::iw4::XAssetHeader convert_asset(game::qos::XAssetHeader header) override
+		{
+			return { convert(header.material) };
+		}
+	};
+}
+
+REGISTER_COMPONENT(material::component)

--- a/src/component/assets/XModel.cpp
+++ b/src/component/assets/XModel.cpp
@@ -1,0 +1,313 @@
+#include <std_include.hpp>
+#include "loader/component_loader.hpp"
+
+#include "component/assethandler.hpp"
+#include "component/command.hpp"
+#include "component/console.hpp"
+#include "component/map_dumper.hpp"
+#include "component/scheduler.hpp"
+
+#include "game/game.hpp"
+#include "game/structs.IW4.hpp"
+
+#include <utils/memory.hpp>
+#include <utils/string.hpp>
+
+namespace xmodel
+{
+	namespace
+	{
+		game::iw4::XModel* convert(game::qos::XModel* xmodel)
+		{
+			if (!xmodel) return nullptr;
+
+			auto iw4_asset = utils::memory::allocate<game::iw4::XModel>();
+
+			iw4_asset->name = xmodel->name;
+			iw4_asset->numBones = xmodel->numBones;
+
+			iw4_asset->numRootBones = xmodel->numRootBones;
+			iw4_asset->numsurfs = xmodel->numsurfs;
+			//iw4_asset->lodRampType = xmodel->lodRampType;
+
+			iw4_asset->scale = 1.0f;
+
+			iw4_asset->boneNames = xmodel->boneNames;
+			iw4_asset->parentList = xmodel->parentList;
+			iw4_asset->quats = xmodel->quats;
+			iw4_asset->trans = xmodel->trans;
+			iw4_asset->partClassification = xmodel->partClassification;
+			iw4_asset->baseMat = xmodel->baseMat;
+
+			iw4_asset->materialHandles = utils::memory::allocate_array<game::iw4::Material*>(xmodel->numsurfs);
+			///TODO - GfxImage is NULLPTR from Material->textureTable. Material->TextureCount could be wrong
+			/*for (size_t i = 0; i < xmodel->numsurfs; i++)
+			{
+				iw4_asset->materialHandles[i] = assethandler::convert_asset_header(game::qos::ASSET_TYPE_MATERIAL, { xmodel->materialHandles[i] }).material;
+			}*/
+
+			for (int i = 0; i < 4; ++i)
+			{
+#if EXTEND_CULLING
+				iw4_asset->lodInfo[i].dist = xmodel->lodInfo[i].dist * 1.5f; // LOD distance is increased so that the maps look nicer in iw4
+#else
+				iw4_asset->lodInfo[i].dist = xmodel->lodInfo[i].dist;
+#endif
+				iw4_asset->lodInfo[i].numsurfs = xmodel->lodInfo[i].numsurfs;
+				iw4_asset->lodInfo[i].surfIndex = xmodel->lodInfo[i].surfIndex;
+
+				// 6 vs 4 part bit elements
+				std::memcpy(iw4_asset->lodInfo[i].partBits, xmodel->lodInfo[i].partBits, sizeof(xmodel->lodInfo[i].partBits));
+
+				iw4_asset->lodInfo[i].lod = xmodel->lodInfo[i].lod;
+
+#if 0
+				// Not correct
+				iw4_asset->lodInfo[i].smcBaseIndexPlusOne = xmodel->lodInfo[i].smcIndexPlusOne;
+				iw4_asset->lodInfo[i].smcSubIndexMask = xmodel->lodInfo[i].smcAllocBits;
+				iw4_asset->lodInfo[i].smcBucket = xmodel->lodInfo[i].unused;
+#else
+				iw4_asset->lodInfo[i].smcBaseIndexPlusOne = 0;
+				iw4_asset->lodInfo[i].smcSubIndexMask = 0;
+				iw4_asset->lodInfo[i].smcBucket = 0;
+#endif
+
+				//	if (iw4_asset->lodInfo[i].numsurfs)
+				//	{
+				//		iw4_asset->lodInfo[i].surfs = utils::memory::allocate_array<game::iw4::XSurface>(iw4_asset->lodInfo[i].numsurfs);
+
+				//		for (unsigned __int16 j = 0; j < iw4_asset->lodInfo[i].numsurfs; ++j)
+				//		{
+				//			game::iw4::XSurface* target = &iw4_asset->lodInfo[i].surfs[j];
+				//			game::qos::XSurface* source = &xmodel->surfs[j + iw4_asset->lodInfo[i].surfIndex];
+
+				//			target->tileMode = source->tileMode;
+				//			target->deformed = source->deformed;
+				//			target->vertCount = source->vertCount;
+				//			target->triCount = source->triCount;
+				//			target->zoneHandle = source->zoneHandle;
+				//			target->baseTriIndex = source->baseTriIndex;
+				//			target->baseVertIndex = source->baseVertIndex;
+				//			target->triIndices = source->triIndices;
+				//			target->vertInfo = source->vertInfo;
+				//			target->verts0 = source->verts0;
+				//			target->vertListCount = source->vertListCount;
+				//			target->vertList = source->vertList;
+
+				//			if (i != iw4_asset->collLod)
+				//			{
+				//				for (size_t k = 0; k < target->vertListCount; k++)
+				//				{
+				//					target->vertList[k].collisionTree = nullptr; // Only collod is used
+				//				}
+				//			}
+
+				//			// 6 vs 4 part bit elements
+				//			std::memcpy(target->partBits, source->partBits, sizeof(source->partBits));
+				//		}
+
+				//		iw4_asset->lodInfo[i].modelSurfs = LocalAllocator.Allocate<game::iw4::XModelSurfs>();
+				//		iw4_asset->lodInfo[i].modelSurfs->name = LocalAllocator.DuplicateString(Utils::VA("%s_lod%d", model->name, i & 0xFF));
+				//		iw4_asset->lodInfo[i].modelSurfs->numSurfaces = static_cast<int>(iw4_asset->lodInfo[i].numsurfs);
+				//		iw4_asset->lodInfo[i].modelSurfs->surfaces = iw4_asset->lodInfo[i].surfs;
+
+				//		// 6 vs 4 part bit elements
+				//		std::memcpy(iw4_asset->lodInfo[i].modelSurfs->partBits, model->lodInfo[i].partBits, sizeof(model->lodInfo[i].partBits));
+				//	}
+				//}
+
+				iw4_asset->numLods = static_cast<char>(xmodel->numLods);
+				iw4_asset->collLod = static_cast<char>(xmodel->collLod);
+				iw4_asset->flags = xmodel->flags;
+
+				if (xmodel->collSurfs)
+				{
+					iw4_asset->collSurfs = utils::memory::allocate_array<game::iw4::XModelCollSurf_s>(xmodel->numCollSurfs);
+					for (int i = 0; i < xmodel->numCollSurfs; ++i)
+					{
+						static_assert(sizeof(game::qos::XModelCollSurf_s) == sizeof(game::iw4::XModelCollSurf_s), "Size mismatch");
+						std::memcpy(&iw4_asset->collSurfs[i], &xmodel->collSurfs[i], sizeof(game::iw4::XModelCollSurf_s));
+						iw4_asset->collSurfs[i].bounds.compute(xmodel->collSurfs[i].mins, xmodel->collSurfs[i].maxs);
+					}
+				}
+
+				iw4_asset->numCollSurfs = xmodel->numCollSurfs;
+				iw4_asset->contents = xmodel->contents;
+
+				if (xmodel->boneInfo)
+				{
+					iw4_asset->boneInfo = utils::memory::allocate_array<game::iw4::XBoneInfo>(xmodel->numBones);
+
+					for (char i = 0; i < xmodel->numBones; ++i)
+					{
+						game::iw4::XBoneInfo* target = &iw4_asset->boneInfo[i];
+						game::qos::XBoneInfo* source = &xmodel->boneInfo[i];
+
+						target->radiusSquared = source->radiusSquared;
+
+						target->bounds.compute(source->bounds[0], source->bounds[1]);
+						target->bounds.midPoint[0] += source->offset[0];
+						target->bounds.midPoint[1] += source->offset[1];
+						target->bounds.midPoint[2] += source->offset[2];
+					}
+				}
+
+				iw4_asset->radius = xmodel->radius;
+
+				iw4_asset->bounds.compute(xmodel->mins, xmodel->maxs);
+
+				iw4_asset->memUsage = xmodel->memUsage;
+				iw4_asset->bad = xmodel->bad;
+				///TODO
+				//iw4_asset->physPreset = xmodel->physPreset;
+
+				if (xmodel->physGeoms)
+				{
+					iw4_asset->physCollmap = utils::memory::allocate<game::iw4::PhysCollmap>();
+					iw4_asset->physCollmap->name = utils::memory::duplicate_string(utils::string::va("%s_colmap", xmodel->name));
+					iw4_asset->physCollmap->count = xmodel->physGeoms->count;
+					iw4_asset->physCollmap->mass = xmodel->physGeoms->mass;
+					iw4_asset->physCollmap->bounds = iw4_asset->bounds; // it's fine right?
+					iw4_asset->physCollmap->geoms = utils::memory::allocate_array<game::iw4::PhysGeomInfo>(xmodel->physGeoms->count);
+
+					for (unsigned int i = 0; i < xmodel->physGeoms->count; ++i)
+					{
+						static_assert(sizeof(game::iw4::PhysGeomInfo) == sizeof(game::qos::PhysGeomInfo), "Size mismatch");
+						game::iw4::PhysGeomInfo* target = &iw4_asset->physCollmap->geoms[i];
+						game::qos::PhysGeomInfo* source = &xmodel->physGeoms->geoms[i];
+
+						std::memcpy(target, source, sizeof(game::iw4::PhysGeomInfo)); // This is ok: IW3 already has "bounds" the way iw4 has, for this struct precisely
+
+						if (source->type >= 4)
+						{
+							// We're going from
+							/*
+								PHYS_GEOM_NONE = 0x0,
+								PHYS_GEOM_BOX = 0x1,
+								PHYS_GEOM_BRUSHMODEL = 0x2,
+								PHYS_GEOM_BRUSH = 0x3,
+								PHYS_GEOM_CYLINDER = 0x4,
+								PHYS_GEOM_CAPSULE = 0x5,
+									PHYS_GEOM_COUNT = 0x6,
+
+							to
+
+								PHYS_GEOM_NONE = 0x0,
+								PHYS_GEOM_BOX = 0x1,
+								PHYS_GEOM_BRUSHMODEL = 0x2,
+								PHYS_GEOM_BRUSH = 0x3,
+									PHYS_GEOM_COLLMAP = 0x4,
+								PHYS_GEOM_CYLINDER = 0x5,
+								PHYS_GEOM_CAPSULE = 0x6,
+									PHYS_GEOM_GLASS = 0x7,
+									PHYS_GEOM_COUNT = 0x8,
+							*/
+
+							target->type += 1;
+
+							console::info("Translated physGeomType %i into %i (geom %i from model %s)\n", source->type, target->type, i, xmodel->name);
+
+							if (source->type >= 0x6)
+							{
+								console::info("Unexpected geom type %i (geom %i from model %s)\n", source->type, i, xmodel->name);
+							}
+						}
+
+						if (source->brush)
+						{
+							target->brush = utils::memory::allocate<game::iw4::BrushWrapper>();//LocalAllocator.Allocate<game::iw4::BrushWrapper>();
+							target->brush->bounds.compute(source->brush->mins, source->brush->maxs);
+
+							target->brush->brush.numsides = static_cast<unsigned short>(source->brush->numsides);
+							target->brush->brush.baseAdjacentSide = source->brush->baseAdjacentSide;
+							target->brush->brush.glassPieceIndex = 0; // IW3's content is not mapped, but I doubt it belongs to this
+
+							std::memcpy(target->brush->brush.axialMaterialNum, source->brush->axialMaterialNum, sizeof(source->brush->axialMaterialNum));
+							std::memcpy(target->brush->brush.edgeCount, source->brush->edgeCount, sizeof(source->brush->edgeCount));
+
+							for (int k = 0; k < 2; ++k)
+							{
+								for (int j = 0; j < 3; ++j)
+								{
+									target->brush->brush.firstAdjacentSideOffsets[k][j] = static_cast<char>(source->brush->firstAdjacentSideOffsets[k][j]);
+								}
+							}
+
+							target->brush->planes = source->brush->planes;
+							target->brush->totalEdgeCount = source->brush->totalEdgeCount;
+
+							target->brush->brush.sides = utils::memory::allocate_array<game::iw4::cbrushside_t>(target->brush->brush.numsides);
+
+							for (unsigned short j = 0; j < target->brush->brush.numsides; ++j)
+							{
+								game::iw4::cbrushside_t* targetSide = &target->brush->brush.sides[j];
+								game::qos::cbrushside_t* sourceSide = &source->brush->sides[j];
+
+								targetSide->plane = sourceSide->plane;
+								targetSide->materialNum = static_cast<unsigned short>(sourceSide->materialNum);
+								targetSide->firstAdjacentSideOffset = static_cast<char>(sourceSide->firstAdjacentSideOffset);
+								targetSide->edgeCount = sourceSide->edgeCount;
+							}
+						}
+					}
+
+					// Physical collision maps don't work!
+					// Porting these on iw4 maps result in models with fucked up physics bouncing everywhere and making noise
+					// and in some cases results in freezes if too many of them move over (fruits in carentan, papers on backlot)
+					// Killing the physCollmap during porting solves this issue with no apparent drawback, surprisingly
+					// The objects (car doors, fruits, ...) still work as expected when this is null. So let's keep it that way until we know what's going on!
+					// The error may lie in the above codeblock, or in zonebuilder's reading of physcollmaps.
+					iw4_asset->physCollmap = nullptr;
+				}
+
+
+				return { iw4_asset };
+			}
+		}
+	}
+
+	class component final : public component_interface
+	{
+	public:
+		void post_load() override
+		{
+			scheduler::once([&]()
+				{
+					command::add("dumpxmodel", [](const command::params& params)
+						{
+							if (params.size() < 2)
+							{
+								console::info("USAGE: dumpxmodel <name>\n");
+								return;
+							}
+
+							const auto name = params[1];
+
+							auto header = game::DB_FindXAssetHeader(game::qos::ASSET_TYPE_XMODEL, name);
+							if (!header.xmodel)
+							{
+								console::error("dumpxmodel failed on '%s'\n", name);
+								return;
+							}
+
+							auto converted = xmodel::convert(header.xmodel);
+							map_dumper::api->write(game::iw4::ASSET_TYPE_XMODEL, converted);
+
+							console::info("dumped '%s' for IW4\n", name);
+						});
+				}, scheduler::main);
+		}
+
+		game::qos::XAssetType get_type() override
+		{
+			return game::qos::ASSET_TYPE_XMODEL;
+		}
+
+		game::iw4::XAssetHeader convert_asset(game::qos::XAssetHeader header) override
+		{
+			return { convert(header.xmodel) };
+		}
+	};
+}
+
+REGISTER_COMPONENT(xmodel::component)

--- a/src/component/entities.cpp
+++ b/src/component/entities.cpp
@@ -1,0 +1,271 @@
+#include <std_include.hpp>
+
+#include <game/game.hpp>
+#include <game/structs.hpp>
+#include <utils/string.hpp>
+#include "entities.hpp"
+
+std::string Entities::Build()
+{
+	std::string entityString;
+
+	for (auto& entity : this->entities)
+	{
+		entityString.append("{\n");
+
+		for (auto& property : entity)
+		{
+			entityString.push_back('"');
+			entityString.append(property.first);
+			entityString.append("\" \"");
+			entityString.append(property.second);
+			entityString.append("\"\n");
+		}
+
+		entityString.append("}\n");
+	}
+
+	return entityString;
+}
+
+std::vector<std::string> Entities::GetModels()
+{
+	std::vector<std::string> models = std::vector<std::string>();
+	std::ofstream destructiblesModelList;
+
+	for (auto& entity : this->entities)
+	{
+		if (entity.find("model") != entity.end())
+		{
+			std::string model = entity["model"];
+
+			if (!model.empty()
+				&& model[0] != '*' && model[0] != '?'  // Skip brushmodels
+				&& model != "com_plasticcase_green_big_us_dirt"s // Skip care package (part of team zones)
+				)
+			{
+				if (std::find(models.begin(), models.end(), model) == models.end())
+				{
+					models.push_back(model);
+				}
+			}
+		}
+	}
+
+	return models;
+}
+
+bool Entities::ConvertVehicles() {
+	bool hasVehicles = false;
+
+	for (auto& entity : this->entities)
+	{
+		if (entity.find("classname") != entity.end())
+		{
+			if (entity.find("targetname") != entity.end() &&
+				entity["targetname"] == "destructible"s &&
+				utils::string::starts_with(entity["destructible_type"], "vehicle"s))
+			{
+				entity["targetname"] = "destructible_vehicle";
+				entity["sound_csv_include"] = "vehicle_car_exp";
+
+				hasVehicles = true;
+			}
+		}
+	}
+
+	return hasVehicles;
+}
+
+void Entities::AddCarePackages()
+{
+	auto subModelCount = 0;
+
+	// We don't have a clipmap reference, so 
+	game::DB_EnumXAssetEntries(game::qos::XAssetType::ASSET_TYPE_CLIPMAP_MP, [&subModelCount](game::qos::XAssetEntryPoolEntry* poolEntry) {
+		auto entry = &poolEntry->entry;
+		if (entry && entry->asset.header.clipMap && subModelCount == 0)
+		{
+			// A clipmap is loaded, we may add the care packages
+			auto clipMap = entry->asset.header.clipMap;
+
+			subModelCount = clipMap->numSubModels;
+		}
+	}, false);
+
+
+	if (subModelCount > 0)
+	{
+		// The last two static models will always be the care packages (but we have not added them yet)
+		auto countWithoutPackages = subModelCount;
+
+		// All values here taken from mp_rust
+		std::unordered_map<std::string, std::string> airdropPalletBrushModel =
+		{
+			{    "script_gameobjectname",    "airdrop_pallet"},
+			{    "targetname",               "iw3x_entity_carepackage"},
+			{    "classname",                "script_brushmodel"},
+			{    "origin",                   "-5072 6560 858"},
+			{    "model",                    "*" + std::to_string(countWithoutPackages) }
+		};
+
+		std::unordered_map<std::string, std::string> airdropPalletScriptModel =
+		{
+			{    "ltOrigin",                 "-5072 6560.19 872.889"},
+			{    "target",                   "iw3x_entity_carepackage"},
+			{    "targetname",               "airdrop_crate"},
+			{    "origin",                   "-5072 6560 858"},
+			{    "classname",                "script_model"},
+			{    "model",                    "com_plasticcase_green_big_us_dirt"}
+		};
+
+		std::unordered_map<std::string, std::string> carePackageBrushModel =
+		{
+			{    "script_gameobjectname",    "airdrop_pallet"},
+			{    "targetname",               "iw3x_entity_airdroppallet"},
+			{    "classname",                "script_brushmodel"},
+			{    "origin",                   "250 325 -299"},
+			{    "model",                    "*" + std::to_string(countWithoutPackages + 1) }
+		};
+
+		std::unordered_map<std::string, std::string> carePackageScriptModel =
+		{
+			{    "ltOrigin",                 "249.7 324.886 -299.611"},
+			{    "target",                   "iw3x_entity_carepackage"},
+			{    "targetname",               "care_package"},
+			{    "origin",                   "249.7 324.7 -314.5"},
+			{    "classname",                "script_model"},
+			{    "model",                    "com_plasticcase_green_big_us_dirt"}
+		};
+
+		entities.push_back(airdropPalletBrushModel);
+		entities.push_back(airdropPalletScriptModel);
+		entities.push_back(carePackageBrushModel);
+		entities.push_back(carePackageScriptModel);
+	}
+}
+
+bool Entities::ConvertTurrets()
+{
+	bool hasTurrets = false;
+
+	for (auto& entity : this->entities)
+	{
+		if (entity.find("classname") != entity.end())
+		{
+			if (entity["classname"] == "misc_turret"s)
+			{
+				entity["weaponinfo"] = "turret_minigun_mp";
+				entity["model"] = "weapon_minigun";
+				hasTurrets = true;
+			}
+		}
+	}
+
+	return hasTurrets;
+}
+
+void Entities::AddRemovedSModels()
+{
+	///todo
+	/*game::qos::GfxWorld* iw3World{};
+
+	game::DB_EnumXAssetEntries(Game::IW3::ASSET_TYPE_GFXWORLD, [&iw3World](Game::IW3::XAssetEntryPoolEntry* entry)
+		{
+			iw3World = entry->entry.asset.header.gfxWorld;
+		}, false);
+
+
+	if (iw3World) {
+		for (auto index : Components::IGfxWorld::removedStaticModelIndices)
+		{
+			auto drawInst = &iw3World->dpvs.smodelDrawInsts[index];
+
+			game::qos::vec3_t angles{};
+			game::AxisToAngles(&angles, drawInst->placement.axis);
+			const std::string origin = Utils::VA("%f %f %f", drawInst->placement.origin[0], drawInst->placement.origin[1], drawInst->placement.origin[2]);
+			const std::string anglesStr = Utils::VA("%f %f %f", angles[0], angles[1], angles[2]);
+
+			std::unordered_map<std::string, std::string> scriptModelEntity =
+			{
+				{    "_comment",                 "added by iw3xport"},
+				{    "classname",                "script_model"},
+				{    "ltOrigin",                 origin},
+				{    "origin",                   origin},
+				{    "angles",                   anglesStr},
+				{    "model",                    drawInst->model->name }
+			};
+
+			entities.push_back(scriptModelEntity);
+		}
+	}*/
+}
+
+void Entities::parse(std::string buffer)
+{
+	int parseState = 0;
+	std::string key;
+	std::string value;
+	std::unordered_map<std::string, std::string> entity;
+
+	for (unsigned int i = 0; i < buffer.size(); ++i)
+	{
+		char character = buffer[i];
+		if (character == '{')
+		{
+			entity.clear();
+		}
+
+		switch (character)
+		{
+		case '{':
+		{
+			entity.clear();
+			break;
+		}
+
+		case '}':
+		{
+			this->entities.push_back(entity);
+			entity.clear();
+			break;
+		}
+
+		case '"':
+		{
+			if (parseState == PARSE_AWAIT_KEY)
+			{
+				key.clear();
+				parseState = PARSE_READ_KEY;
+			}
+			else if (parseState == PARSE_READ_KEY)
+			{
+				parseState = PARSE_AWAIT_VALUE;
+			}
+			else if (parseState == PARSE_AWAIT_VALUE)
+			{
+				value.clear();
+				parseState = PARSE_READ_VALUE;
+			}
+			else if (parseState == PARSE_READ_VALUE)
+			{
+				entity[utils::string::to_lower(key)] = value;
+				parseState = PARSE_AWAIT_KEY;
+			}
+			else
+			{
+				throw std::runtime_error("Parsing error!");
+			}
+			break;
+		}
+
+		default:
+		{
+			if (parseState == PARSE_READ_KEY) key.push_back(character);
+			else if (parseState == PARSE_READ_VALUE) value.push_back(character);
+
+			break;
+		}
+		}
+	}
+}

--- a/src/component/entities.hpp
+++ b/src/component/entities.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+class Entities
+{
+public:
+	Entities() {};
+	Entities(const char* string, size_t lenPlusOne) : Entities(std::string(string, lenPlusOne - 1)) {}
+	Entities(std::string buffer) : Entities() { this->parse(buffer); };
+	Entities(const Entities& obj) : entities(obj.entities) {};
+
+	std::string Build();
+
+	std::vector<std::string> GetModels();
+	bool ConvertTurrets();
+	bool ConvertVehicles();
+	void AddCarePackages();
+	void AddRemovedSModels();
+
+private:
+	enum
+	{
+		PARSE_AWAIT_KEY,
+		PARSE_READ_KEY,
+		PARSE_AWAIT_VALUE,
+		PARSE_READ_VALUE,
+	};
+
+	std::vector<std::unordered_map<std::string, std::string>> entities;
+	void parse(std::string buffer);
+};

--- a/src/component/map_dumper.cpp
+++ b/src/component/map_dumper.cpp
@@ -118,9 +118,13 @@ namespace map_dumper
 			console::info("exporting GameWorld...\n");
 			command::execute(utils::string::va("dumpgameworld %s", bsp_name.data()));
 
+			// This is redundant with clipmap but allows exporting more models
+			console::info("Exporting Entities...\n");
+			command::execute(utils::string::va("dumpMapEnts %s", bsp_name.data()));
+
 			// TODO
-			console::info("exporting GfxWorld...\n");
-			command::execute(utils::string::va("dumpgfxworld %s", bsp_name.data()));
+			/*console::info("exporting GfxWorld...\n");
+			command::execute(utils::string::va("dumpgfxworld %s", bsp_name.data()));*/
 		}
 	}
 

--- a/src/component/patches.cpp
+++ b/src/component/patches.cpp
@@ -10,7 +10,7 @@
 #include <utils/hook.hpp>
 #include <utils/string.hpp>
 
-#define FORCE_BORDERLESS true
+#define FORCE_BORDERLESS
 
 namespace patches
 {
@@ -33,6 +33,11 @@ namespace patches
 
 			return CreateWindowExA(ex_style, class_name, window_name, style, x, y, width, height, parent, menu, inst, param);
 		}
+
+		int PlayListBypass(DWORD* unk, int a2)
+		{
+			return 1;
+		}
 	}
 
 	class component final : public component_interface
@@ -54,6 +59,13 @@ namespace patches
 
 			// un-cap fps
 			utils::hook::set<uint8_t>(game::game_offset(0x103F696A), 0x00);
+
+			// Bypass playlist + stats
+			utils::hook::jump(game::game_offset(0x10240B30), PlayListBypass);
+			utils::hook::jump(game::game_offset(0x10240A30), PlayListBypass);
+
+			// Allow map Loading
+			utils::hook::nop(game::game_offset(0x102489A1), 5);
 		}
 	};
 }

--- a/src/component/patches.cpp
+++ b/src/component/patches.cpp
@@ -11,6 +11,7 @@
 #include <utils/string.hpp>
 
 #define FORCE_BORDERLESS
+#define XLIVELESS
 
 namespace patches
 {
@@ -44,6 +45,8 @@ namespace patches
 			}
 
 			return link_xasset_entry_hook.invoke<game::qos::XAssetEntry*>(entry, override);
+		}
+
 		int PlayListBypass(DWORD* unk, int a2)
 		{
 			return 1;
@@ -75,6 +78,7 @@ namespace patches
 			//link_xasset_entry_hook.create(game::game_offset(0x103E0640), link_xasset_entry_stub);
 #endif
 
+#ifdef XLIVELESS
 			// stop disconnect error when starting match
 			// Bypass playlist + stats
 			utils::hook::jump(game::game_offset(0x10240B30), PlayListBypass);
@@ -82,6 +86,7 @@ namespace patches
 
 			// Allow map Loading
 			utils::hook::nop(game::game_offset(0x102489A1), 5);
+#endif
 		}
 	};
 }

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -39,6 +39,7 @@ namespace game
 	void Cbuf_AddText(int controller, const char* text);
 	void Cmd_AddCommandInternal(const char* name, void(__cdecl* function)(), qos::cmd_function_s* cmd);
 	bool DB_IsXAssetDefault(qos::XAssetType type, const char* name);
+	void DB_EnumXAssetEntries(qos::XAssetType type, std::function<void(qos::XAssetEntryPoolEntry*)> callback, bool overrides);
 }
 
 #include "symbols.hpp"

--- a/src/game/structs.IW4.hpp
+++ b/src/game/structs.IW4.hpp
@@ -161,10 +161,10 @@ namespace game::iw4
 		unsigned char semantic;
 		unsigned char category;
 		bool useSrgbReads;
-		// TODO //qos::Picmip picmip;
+		qos::Picmip picmip;
 		bool noPicmip;
 		char track;
-		// TODO //qos::CardMemory cardMemory;
+		qos::CardMemory cardMemory;
 		unsigned short width;
 		unsigned short height;
 		unsigned short depth;
@@ -728,7 +728,7 @@ namespace game::iw4
 
 	struct cbrushside_t
 	{
-		// TODO //qos::cplane_s* plane;
+		qos::cplane_s* plane;
 		unsigned __int16 materialNum;
 		char firstAdjacentSideOffset;
 		char edgeCount;
@@ -751,7 +751,7 @@ namespace game::iw4
 		Bounds bounds;
 		cbrush_t brush;
 		int totalEdgeCount;
-		// TODO //qos::cplane_s* planes;
+		qos::cplane_s* planes;
 	};
 #pragma pack(pop)
 
@@ -769,7 +769,7 @@ namespace game::iw4
 		const char* name;
 		unsigned int count;
 		PhysGeomInfo* geoms;
-		// TODO //qos::PhysMass mass;
+		qos::PhysMass mass;
 		Bounds bounds;
 	};
 
@@ -814,7 +814,7 @@ namespace game::iw4
 
 	struct XModelCollSurf_s
 	{
-		// TODO //qos::XModelCollTri_s* collTris;
+		qos::XModelCollTri_s* collTris;
 		int numCollTris;
 		Bounds bounds;
 		int boneIdx;
@@ -836,7 +836,7 @@ namespace game::iw4
 		__int16* quats;
 		float* trans;
 		unsigned char* partClassification;
-		// TODO //qos::DObjAnimMat* baseMat;
+		qos::DObjAnimMat* baseMat;
 		Material** materialHandles;
 		XModelLodInfo lodInfo[4];
 		char maxLoadedLod;
@@ -851,7 +851,7 @@ namespace game::iw4
 		Bounds bounds;
 		int memUsage;
 		bool bad;
-		// TODO //qos::PhysPreset* physPreset;
+		qos::PhysPreset* physPreset;
 		PhysCollmap* physCollmap;
 	};
 
@@ -1323,8 +1323,8 @@ namespace game::iw4
 		char cameraRegion;
 		MaterialTechniqueSet* techniqueSet;
 		MaterialTextureDef* textureTable;
-		// TODO //qos::MaterialConstantDef* constantTable;
-		// TODO //qos::GfxStateBits* stateBitTable;
+		game::qos::MaterialConstantDef* constantTable;
+		game::qos::GfxStateBits* stateBitTable;
 	};
 #pragma pack(pop)
 

--- a/src/game/structs.hpp
+++ b/src/game/structs.hpp
@@ -63,6 +63,680 @@ namespace game::qos
 		ASSET_TYPE_INVALID = -1
 	};
 
+	struct Bounds
+	{
+		vec3_t midPoint;
+		vec3_t halfSize;
+	};
+
+#pragma region clipmap
+
+
+#pragma pack(push, 4)
+	struct cLeaf_t
+	{
+		unsigned __int16 firstCollAabbIndex;
+		unsigned __int16 collAabbCount;
+		int brushContents;
+		int terrainContents;
+		float mins[3];
+		float maxs[3];
+		int leafBrushNode;
+		__int16 cluster;
+	};
+#pragma pack(pop)
+
+	struct cmodel_t
+	{
+		float mins[3];
+		float maxs[3];
+		float radius;
+		cLeaf_t leaf;
+	};
+
+	struct cplane_s;
+	struct cbrushside_t;
+
+	struct MapEnts
+	{
+		const char* name;
+		char* entityString;
+		int numEntityChars; // The structure actually ends here...
+	};
+	static_assert(sizeof(MapEnts) == 0xC);
+
+	struct clipMap_t
+	{
+		const char* name;
+		int isInUse;
+		int planeCount;
+		cplane_s* planes;
+		unsigned int numStaticModels;
+		void* staticModelList;
+		unsigned int numMaterials;
+		void* materials;
+		unsigned int numBrushSides;
+		cbrushside_t* brushsides;
+		char pad_0028[108]; //0x0028
+		unsigned int numSubModels; //0x0094
+		cmodel_t* cmodels; //0x0098
+		char pad_009C[24]; //0x009C
+		MapEnts* mapEnts; //0xB4
+		char pad_00B8[140]; //0x00B8
+	};
+	static_assert(sizeof(clipMap_t) == 0x144);
+#pragma endregion
+
+	struct GfxImageFileHeader
+	{
+		char tag[3];
+		char version;
+		char format;
+		char flags;
+		short dimensions[3];
+		int fileSizeForPicmip[4];
+	};
+
+	struct GfxImageLoadDef
+	{
+		char levelCount;
+		char flags;
+		__int16 dimensions[3];
+		int format;
+		int resourceSize;
+		char data[1];
+	};
+
+	union GfxTexture
+	{
+		GfxImageLoadDef* loadDef;
+		void* data;
+	};
+
+	enum file_image_flags_t
+	{
+		IMG_FLAG_NOPICMIP = 0x1,
+		IMG_FLAG_NOMIPMAPS = 0x2,
+		IMG_FLAG_CUBEMAP = 0x4,
+		IMG_FLAG_VOLMAP = 0x8,
+		IMG_FLAG_STREAMING = 0x10,
+		IMG_FLAG_LEGACY_NORMALS = 0x20,
+		IMG_FLAG_CLAMP_U = 0x40,
+		IMG_FLAG_CLAMP_V = 0x80,
+		IMG_FLAG_DYNAMIC = 0x10000,
+		IMG_FLAG_RENDER_TARGET = 0x20000,
+		IMG_FLAG_SYSTEMMEM = 0x40000,
+	};
+
+	struct Picmip
+	{
+		char platform[2];
+	};
+
+	struct CardMemory
+	{
+		int platform[2];
+	};
+
+	struct GfxImage
+	{
+		char mapType;
+		GfxTexture texture;
+		Picmip picmip;
+		bool noPicmip;
+		char semantic;
+		char track;
+		CardMemory cardMemory;
+		unsigned __int16 width;
+		unsigned __int16 height;
+		unsigned __int16 depth;
+		char category;
+		bool delayLoadPixels;
+		const char* name;
+	};
+
+	static_assert(sizeof(GfxImage) == 0x24);
+
+	struct DObjAnimMat
+	{
+		float quat[4];
+		float trans[3];
+		float transWeight;
+	};
+
+	struct XSurface
+	{
+		char _pad0[80];
+	};
+
+	static_assert(sizeof(XSurface) == 0x50);
+
+	struct XModelCollTri_s
+	{
+		float plane[4];
+		float svec[4];
+		float tvec[4];
+	};
+
+	struct XModelCollSurf_s
+	{
+		XModelCollTri_s* collTris;
+		int numCollTris;
+		float mins[3];
+		float maxs[3];
+		int boneIdx;
+		int contents;
+		int surfFlags;
+	};
+
+	static_assert(sizeof(XModelCollSurf_s) == 44);
+
+	struct XBoneInfo
+	{
+		float bounds[2][3];
+		float offset[3];
+		float radiusSquared;
+	};
+
+	static_assert(sizeof(XBoneInfo) == 40);
+
+	struct PhysPreset;
+
+	struct cplane_s
+	{
+		float normal[3];
+		float dist;
+		char type;
+		char signbits;
+		char pad[2];
+	};
+
+#pragma pack(push, 2)
+	struct cbrushside_t
+	{
+		cplane_s* plane;
+		unsigned int materialNum;
+		__int16 firstAdjacentSideOffset;
+		char edgeCount;
+	};
+#pragma pack(pop)
+
+	struct BrushWrapper
+	{
+		float mins[3];
+		int contents;
+		float maxs[3];
+		unsigned int numsides;
+		cbrushside_t* sides;
+		__int16 axialMaterialNum[2][3];
+		char* baseAdjacentSide;
+		__int16 firstAdjacentSideOffsets[2][3];
+		char edgeCount[2][3];
+		int totalEdgeCount;
+		cplane_s* planes;
+	};
+
+	struct PhysMass
+	{
+		float centerOfMass[3];
+		float momentsOfInertia[3];
+		float productsOfInertia[3];
+	};
+
+	struct PhysGeomInfo
+	{
+		BrushWrapper* brush;
+		int type;
+		float orientation[3][3];
+		float offset[3];
+		float halfLengths[3];
+	};
+
+	struct PhysGeomList
+	{
+		unsigned int count;
+		PhysGeomInfo* geoms;
+		PhysMass mass;
+	};
+
+	struct XModelLodInfo
+	{
+		float dist;
+		unsigned __int16 numsurfs;
+		unsigned __int16 surfIndex;
+		int partBits[4];
+		char lod;
+		char smcIndexPlusOne;
+		char smcAllocBits;
+		char unused;
+		char crap[4];
+	};
+
+	struct Material;
+
+
+#pragma pack(push, 4)
+	struct XModel
+	{
+		const char* name;
+		char numBones;
+		char numRootBones;
+		char numsurfs;
+		unsigned __int16* boneNames;
+		unsigned char* parentList;
+		__int16* quats;
+		float* trans;
+		unsigned char* partClassification;
+		DObjAnimMat* baseMat;
+		XSurface* surfs;
+		Material** materialHandles;
+		XModelLodInfo lodInfo[4]; //char _pad0[128];
+		XModelCollSurf_s* collSurfs;
+		int numCollSurfs;
+		int contents;
+		XBoneInfo* boneInfo; //0xB4
+		float radius; //char _pad2[48];
+		float mins[3];
+		float maxs[3];
+		__int16 numLods;
+		__int16 collLod;
+		void* streamInfo;
+		int memUsage;
+		char flags;
+		bool bad;
+		void* _pad2;
+		PhysPreset* physPreset;
+		PhysGeomList* physGeoms;
+	};
+#pragma pack(pop)
+
+	static_assert(sizeof(XModel) == 0xF0);
+
+	struct GfxDrawSurfFields
+	{
+		unsigned __int64 objectId : 16;
+		unsigned __int64 reflectionProbeIndex : 8;
+		unsigned __int64 customIndex : 5;
+		unsigned __int64 materialSortedIndex : 11;
+		unsigned __int64 prepass : 2;
+		unsigned __int64 primaryLightIndex : 8;
+		unsigned __int64 surfType : 4;
+		unsigned __int64 primarySortKey : 6;
+		unsigned __int64 unused : 4;
+	};
+
+	union GfxDrawSurf
+	{
+		GfxDrawSurfFields fields;
+		unsigned __int64 packed;
+	};
+
+	struct MaterialGameFlagsFields
+	{
+		unsigned char unk1 : 1; // 0x1
+		unsigned char addShadowToPrimaryLight : 1; // 0x2
+		unsigned char isFoliageRequiresGroundLighting : 1; // 0x4
+		unsigned char unk4 : 1; // 0x8
+		unsigned char unk5 : 1; // 0x10
+		unsigned char unk6 : 1; // 0x20
+		unsigned char MTL_GAMEFLAG_CASTS_SHADOW : 1; // 0x40
+		unsigned char unkNeededForSModelDisplay : 1; // 0x80
+	};
+
+	union MaterialGameFlags
+	{
+		MaterialGameFlagsFields fields;
+		unsigned char packed;
+	};
+
+	struct MaterialInfo
+	{
+		const char* name;
+		MaterialGameFlags gameFlags;
+		char sortKey;
+		char textureAtlasRowCount;
+		char textureAtlasColumnCount;
+		GfxDrawSurf drawSurf;
+		unsigned int surfaceTypeBits;
+		unsigned __int16 hashIndex;
+	};
+	static_assert(sizeof(MaterialInfo) == 0x18);
+
+	struct MaterialArgumentCodeConst
+	{
+		unsigned __int16 index;
+		char firstRow;
+		char rowCount;
+	};
+
+	union MaterialArgumentDef
+	{
+		const float* literalConst;
+		MaterialArgumentCodeConst codeConst;
+		unsigned int codeSampler;
+		unsigned int nameHash;
+	};
+
+	struct MaterialShaderArgument
+	{
+		unsigned __int16 type;
+		unsigned __int16 dest;
+		MaterialArgumentDef u;
+	};
+
+	struct MaterialPass
+	{
+		void* vertexDecl;
+		void* vertexShader;
+		void* pixelShader;
+		char perPrimArgCount;
+		char perObjArgCount;
+		char stableArgCount;
+		char customSamplerFlags;
+		MaterialShaderArgument* args;
+	};
+
+	struct MaterialTechnique
+	{
+		const char* name;
+		unsigned __int16 flags;
+		unsigned __int16 numPasses;
+		MaterialPass pass[1];
+	};
+
+	struct MaterialTechniqueSet
+	{
+		const char* name;
+		char worldVertFormat;
+		char unused[2];
+		MaterialTechniqueSet* remappedTechniqueSet;
+		MaterialTechnique* techniques[43];
+	};
+
+	struct MaterialTextureDef
+	{
+		unsigned int typeHash;
+		char firstCharacter;
+		char secondLastCharacter;
+		char sampleState;
+		char semantic;
+		GfxImage* image;
+	};
+
+	struct MaterialConstantDef
+	{
+		unsigned int nameHash;
+		char name[12];
+		vec4_t literal;
+	};
+
+	enum GfxSurfaceStatebitOp0 : unsigned int
+	{
+		GFXS0_SRCBLEND_RGB_SHIFT = 0x0,
+		GFXS0_SRCBLEND_RGB_MASK = 0xF,
+		GFXS0_DSTBLEND_RGB_SHIFT = 0x4,
+		GFXS0_DSTBLEND_RGB_MASK = 0xF0,
+		GFXS0_BLENDOP_RGB_SHIFT = 0x8,
+		GFXS0_BLENDOP_RGB_MASK = 0x700,
+		GFXS0_BLEND_RGB_MASK = 0x7FF,
+		GFXS0_ATEST_DISABLE = 0x800,
+		GFXS0_ATEST_GT_0 = 0x1000,
+		GFXS0_ATEST_LT_128 = 0x2000,
+		GFXS0_ATEST_GE_128 = 0x3000,
+		GFXS0_ATEST_MASK = 0x3000,
+		GFXS0_CULL_SHIFT = 0xE,
+		GFXS0_CULL_NONE = 0x4000,
+		GFXS0_CULL_BACK = 0x8000,
+		GFXS0_CULL_FRONT = 0xC000,
+		GFXS0_CULL_MASK = 0xC000,
+		GFXS0_SRCBLEND_ALPHA_SHIFT = 0x10,
+		GFXS0_SRCBLEND_ALPHA_MASK = 0xF0000,
+		GFXS0_DSTBLEND_ALPHA_SHIFT = 0x14,
+		GFXS0_DSTBLEND_ALPHA_MASK = 0xF00000,
+		GFXS0_BLENDOP_ALPHA_SHIFT = 0x18,
+		GFXS0_BLENDOP_ALPHA_MASK = 0x7000000,
+		GFXS0_BLEND_ALPHA_MASK = 0x7FF0000,
+		GFXS0_COLORWRITE_RGB = 0x8000000,
+		GFXS0_COLORWRITE_ALPHA = 0x10000000,
+		GFXS0_COLORWRITE_MASK = 0x18000000,
+		GFXS0_POLYMODE_LINE = 0x80000000
+	};
+
+	enum GfxSurfaceStatebitOp1 : unsigned int
+	{
+		GFXS1_DEPTHWRITE = 0x1,
+		GFXS1_DEPTHTEST_DISABLE = 0x2,
+		GFXS1_DEPTHTEST_SHIFT = 0x2,
+		GFXS1_DEPTHTEST_ALWAYS = 0x0,
+		GFXS1_DEPTHTEST_LESS = 0x4,
+		GFXS1_DEPTHTEST_EQUAL = 0x8,
+		GFXS1_DEPTHTEST_LESSEQUAL = 0xC,
+		GFXS1_DEPTHTEST_MASK = 0xC,
+		GFXS1_POLYGON_OFFSET_SHIFT = 0x4,
+		GFXS1_POLYGON_OFFSET_0 = 0x0,
+		GFXS1_POLYGON_OFFSET_1 = 0x10,
+		GFXS1_POLYGON_OFFSET_2 = 0x20,
+		GFXS1_POLYGON_OFFSET_SHADOWMAP = 0x30,
+		GFXS1_POLYGON_OFFSET_MASK = 0x30,
+		GFXS1_STENCIL_FRONT_ENABLE = 0x40,
+		GFXS1_STENCIL_BACK_ENABLE = 0x80,
+		GFXS1_STENCIL_MASK = 0xC0,
+		GFXS1_STENCIL_FRONT_PASS_SHIFT = 0x8,
+		GFXS1_STENCIL_FRONT_FAIL_SHIFT = 0xB,
+		GFXS1_STENCIL_FRONT_ZFAIL_SHIFT = 0xE,
+		GFXS1_STENCIL_FRONT_FUNC_SHIFT = 0x11,
+		GFXS1_STENCIL_FRONT_MASK = 0xFFF00,
+		GFXS1_STENCIL_BACK_PASS_SHIFT = 0x14,
+		GFXS1_STENCIL_BACK_FAIL_SHIFT = 0x17,
+		GFXS1_STENCIL_BACK_ZFAIL_SHIFT = 0x1A,
+		GFXS1_STENCIL_BACK_FUNC_SHIFT = 0x1D,
+		GFXS1_STENCIL_BACK_MASK = 0xFFF00000,
+		GFXS1_STENCILFUNC_FRONTBACK_MASK = 0xE00E0000,
+		GFXS1_STENCILOP_FRONTBACK_MASK = 0x1FF1FF00,
+	};
+
+	struct GfxStatebitsFlags {
+		GfxSurfaceStatebitOp0 loadbit0;
+		GfxSurfaceStatebitOp1 loadbit1;
+	};
+
+	union GfxStateBits
+	{
+		GfxStatebitsFlags flags;
+		int loadBits[2];
+	};
+
+	struct Material
+	{
+		MaterialInfo info;
+		char stateBitsEntry[55];
+		char textureCount;
+		char constantCount;
+		char stateBitsCount;
+		char stateFlags;
+		char cameraRegion;
+		MaterialTechniqueSet* techniqueSet; //0x54
+		MaterialTextureDef* textureTable;
+		MaterialConstantDef* contantTable;
+		GfxStateBits* stateBitsTable;
+	};
+	static_assert(sizeof(Material) == 0x68);
+
+	struct FxSpawnDefLooping
+	{
+		int intervalMsec;
+		int count;
+	};
+
+	struct FxIntRange
+	{
+		int base;
+		int amplitude;
+	};
+
+	struct FxSpawnDefOneShot
+	{
+		FxIntRange count;
+	};
+
+	union FxSpawnDef
+	{
+		FxSpawnDefLooping looping;
+		FxSpawnDefOneShot oneShot;
+	};
+
+	struct FxFloatRange
+	{
+		float base;
+		float amplitude;
+	};
+
+	struct FxElemAtlas
+	{
+		char behavior;
+		char index;
+		char fps;
+		char loopCount;
+		char colIndexBits;
+		char rowIndexBits;
+		__int16 entryCount;
+	};
+
+	struct FxElemVec3Range
+	{
+		float base[3];
+		float amplitude[3];
+	};
+
+	struct FxElemVelStateInFrame
+	{
+		FxElemVec3Range velocity;
+		FxElemVec3Range totalDelta;
+	};
+
+	const struct FxElemVelStateSample
+	{
+		FxElemVelStateInFrame local;
+		FxElemVelStateInFrame world;
+	};
+
+	struct FxElemVisualState
+	{
+		char color[4];
+		float rotationDelta;
+		float rotationTotal;
+		float size[2];
+		float scale;
+	};
+
+	const struct FxElemVisStateSample
+	{
+		FxElemVisualState base;
+		FxElemVisualState amplitude;
+	};
+
+	struct FxEffectDef;
+
+	union FxEffectDefRef
+	{
+		FxEffectDef* handle;
+		const char* name;
+	};
+
+	union FxElemVisuals
+	{
+		const void* anonymous;
+		Material* material;
+		XModel* model;
+		FxEffectDefRef effectDef;
+		const char* soundName;
+	};
+
+	struct FxElemMarkVisuals
+	{
+		Material* materials[2];
+	};
+
+	union FxElemDefVisuals
+	{
+		FxElemMarkVisuals* markArray;
+		FxElemVisuals* array;
+		FxElemVisuals instance;
+	};
+
+	struct FxTrailVertex
+	{
+		float pos[2];
+		float normal[2];
+		float texCoord;
+	};
+
+	struct FxTrailDef
+	{
+		int scrollTimeMsec;
+		int repeatDist;
+		int splitDist;
+		int vertCount;
+		FxTrailVertex* verts;
+		int indCount;
+		unsigned __int16* inds;
+	};
+
+	const struct FxElemDef
+	{
+		int flags;
+		FxSpawnDef spawn;
+		FxFloatRange spawnRange;
+		FxFloatRange fadeInRange;
+		FxFloatRange fadeOutRange;
+		float spawnFrustumCullRadius;
+		FxIntRange spawnDelayMsec;
+		FxIntRange lifeSpanMsec;
+		FxFloatRange spawnOrigin[3];
+		FxFloatRange spawnOffsetRadius;
+		FxFloatRange spawnOffsetHeight;
+		FxFloatRange spawnAngles[3];
+		FxFloatRange angularVelocity[3];
+		FxFloatRange initialRotation;
+		FxFloatRange gravity;
+		FxFloatRange reflectionFactor;
+		FxElemAtlas atlas;
+		char elemType;
+		char visualCount;
+		char velIntervalCount;
+		char visStateIntervalCount;
+		FxElemVelStateSample* velSamples;
+		FxElemVisStateSample* visSamples;
+		FxElemDefVisuals visuals;
+		Bounds collBounds;
+		FxEffectDefRef effectOnImpact;
+		FxEffectDefRef effectOnDeath;
+		FxEffectDefRef effectEmitted;
+		FxFloatRange emitDist;
+		FxFloatRange emitDistVariance;
+		FxTrailDef* trailDef;
+		char sortOrder;
+		char lightingFrac;
+		char useItemClip;
+		char unused[1];
+	};
+
+	static_assert(sizeof(FxElemDef) == 0xFC);
+
+	struct FxEffectDef
+	{
+		const char* name;
+		int flags;
+		int totalSize;
+		int msecLoopingLife;
+		int elemDefCountLooping;
+		int elemDefCountOneShot;
+		int elemDefCountEmission;
+		FxElemDef* elemDefs;
+	};
+
+	static_assert(sizeof(FxEffectDef) == 0x20);
+
 #pragma pack(push, 4)
 	struct PhysPreset
 	{
@@ -123,33 +797,29 @@ namespace game::qos
 		//void* g_glassData; // 4
 	}; static_assert(sizeof(gameWorldMp) == 4);
 
-	struct GfxImage
-	{
-		// TODO
-	};
 
 	// slightly different than IW3
-	struct GfxWorld
-	{
-		const char* name;			// 0
-		const char* baseName;		// 4
-		int planeCount;				// 8
-		void* planes;				// 12 (pointer is next to count now)
-		int nodeCount;				// 16
-		void* nodes;				// 20 ^
-		int indexCount;				// 24
-		unsigned __int16* indices;	// 28 ^
-		int surfaceCount;			// 32
-		void* surfaces;				// 36 ^
-		char __pad0[20];			// 40 (unresearched)
-		int skySurfCount;			// 60
-		int* skyStartSurfs;			// 64
-		GfxImage* skyImage;			// 68
-		char __pad0[4];				// 72 (unresearched)
-		const char* unk;			// 76 (varXString used)
+	//struct GfxWorld
+	//{
+	//	const char* name;			// 0
+	//	const char* baseName;		// 4
+	//	int planeCount;				// 8
+	//	void* planes;				// 12 (pointer is next to count now)
+	//	int nodeCount;				// 16
+	//	void* nodes;				// 20 ^
+	//	int indexCount;				// 24
+	//	unsigned __int16* indices;	// 28 ^
+	//	int surfaceCount;			// 32
+	//	void* surfaces;				// 36 ^
+	//	char __pad0[20];			// 40 (unresearched)
+	//	int skySurfCount;			// 60
+	//	int* skyStartSurfs;			// 64
+	//	GfxImage* skyImage;			// 68
+	//	char __pad1[4];				// 72 (unresearched)
+	//	const char* unk;			// 76 (varXString used)
 
-		// TODO
-	}; static_assert(sizeof(GfxWorld) == 728); // 732 -> 728 (4 byte difference from COD4..)
+	//	// TODO
+	//}; static_assert(sizeof(GfxWorld) == 728, "GfxWorld is the wrong size"); // 732 -> 728 (4 byte difference from COD4..)
 
 	union XAssetHeader
 	{
@@ -158,11 +828,14 @@ namespace game::qos
 		PhysPreset* physPreset; // not done
 		//void* physConstraints;
 		//void* destructibleDef;
+		Material* material;
+		GfxImage* image;
+		XModel* xmodel;
 		ComWorld* comWorld;
 		//gameWorldSp* gameWorldSp;
 		gameWorldMp* gameWorldMp;
-
-		GfxWorld* gfxWorld;
+		clipMap_t* clipMap;
+		//GfxWorld* gfxWorld;
 
 		RawFile* rawfile;
 	};

--- a/src/game/symbols.hpp
+++ b/src/game/symbols.hpp
@@ -13,4 +13,7 @@ namespace game
 	WEAK symbol<char**> cmd_argv{ game_offset(0x10752CD4) };
 	WEAK symbol<qos::cmd_function_s*> cmd_functions{ game_offset(0x10752CF8) };
 	WEAK symbol<qos::scrMemTreePub_t> scrMemTreePub{ game_offset(0x116357CC) };
+
+	WEAK symbol<unsigned short*> db_hashTable{ game_offset(0x1082ED60) };
+	WEAK symbol<qos::XAssetEntryPoolEntry> g_assetEntryPool{ game_offset(0x108CB5C0) };
 }


### PR DESCRIPTION
- Some more structs mapped
- mapEnts/Models are dumped
- Started on Material (possible issue with textureCount being incorrect)
- Added GfxImage Asset Dumper (two hooks are commented out - StoreTexture and ReleaseTexture**)
- FXEffectDef struct is identical to COD4, just not included the dumper for now


**StoreTexture Hook is the correct address, however, without the ReleaseTexture function, game will crash.
**ReleaseTexture is at `0x488C00` on COD4 (1.7) but its a broken function in IDA